### PR TITLE
Update README.md (add requirement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # GraphQL Playground
 Mount the [GraphQL Playground](https://github.com/prisma/graphql-playground) in Ruby on Rails.
 
+## Requirement
+Rails >= 5.2.0
+
 ## Installation
 Add this line to your application's Gemfile:
 


### PR DESCRIPTION
Unfortunately i was use `5.1.4`.
This version not included `csp_meta_tag`. Therefore i did check which version included.
I found `5.2.0` is included `csp_meta_tag` and did try work or not.
https://api.rubyonrails.org/v5.2.0/classes/ActionView/Helpers/CspHelper.html#method-i-csp_meta_tag
FYI. if you try install rails `5.2.0` then install `5.2.3`