### PR TITLE
Update README.md (routes.rb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the engine to routes.rb:
 Rails.application.routes.draw do
   # ...
   if Rails.env.development?
-    mount GraphQL::Playground::Engine, at: "/graphql-playground", graphql_path: "/graphql"
+    mount GraphqlPlayground::Rails::Engine, at: "/graphql-playground", graphql_path: "/graphql"
   end
 end
 ```


### PR DESCRIPTION
The previous example showed in the README.md caused the following error : 

`uninitialized constant GraphQL::Playground (NameError)`